### PR TITLE
Mirror of mapbox mapbox-android-demo#1252

### DIFF
--- a/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -29,6 +29,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.mapbox.mapboxandroiddemo.adapter.ExampleAdapter;
 import com.mapbox.mapboxandroiddemo.commons.AnalyticsTracker;
 import com.mapbox.mapboxandroiddemo.commons.FirstTimeRunChecker;
+import com.mapbox.mapboxandroiddemo.examples.ChinaBoundsCheckerActivity;
 import com.mapbox.mapboxandroiddemo.examples.SimpleChinaMapViewActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.AnimatedMarkerActivity;
 import com.mapbox.mapboxandroiddemo.examples.basics.KotlinSimpleMapViewActivity;
@@ -388,6 +389,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, SimpleChinaMapViewActivity.class),
       null,
       R.string.activity_china_simple_china_mapview_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+        R.id.nav_basics,
+        R.string.activity_china_simple_china_bounds_checker_title,
+        R.string.activity_china_simple_china_bounds_checker_description,
+        new Intent(MainActivity.this, ChinaBoundsCheckerActivity.class),
+        null,
+        R.string.activity_china_simple_china_bounds_checker_url, false, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_styles,

--- a/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/examples/ChinaBoundsCheckerActivity.kt
+++ b/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/examples/ChinaBoundsCheckerActivity.kt
@@ -1,0 +1,199 @@
+package com.mapbox.mapboxandroiddemo.examples
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.widget.Toast
+import androidx.annotation.NonNull
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.android.core.location.*
+import com.mapbox.android.core.permissions.PermissionsListener
+import com.mapbox.android.core.permissions.PermissionsManager
+import com.mapbox.mapboxandroiddemo.R
+import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.location.LocationComponent
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions
+import com.mapbox.mapboxsdk.location.modes.CameraMode
+import com.mapbox.mapboxsdk.location.modes.RenderMode
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.MapboxMapOptions
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.plugins.china.constants.ChinaStyle
+import com.mapbox.mapboxsdk.plugins.china.maps.ChinaMapView
+import com.mapbox.mapboxsdk.plugins.china.shift.ChinaBoundsChecker
+
+class ChinaBoundsCheckerActivity : AppCompatActivity(), OnMapReadyCallback,
+        LocationEngineCallback<LocationEngineResult>, PermissionsListener {
+
+    private lateinit var mapboxMap: MapboxMap
+    private var savedInstanceState: Bundle? = null
+    private var deviceInChina: Boolean? = null
+    private var chinaMapView: ChinaMapView? = null
+    private var locationComponent: LocationComponent? = null
+    private var permissionsManager: PermissionsManager? = null
+    private var locationEngine: LocationEngine? = null
+    private val defaultIntervalInMilliseconds = 1000L
+    private val defaultMaxWaitTime = defaultIntervalInMilliseconds * 5
+
+    // Adjust the Styles below to see various China and non-China styles used in this example
+    private val chinaStyleToUse: String = ChinaStyle.MAPBOX_DARK_CHINESE
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Mapbox access token is configured here. This needs to be called either in your application
+        // object or in the same activity which contains the mapview.
+        this.savedInstanceState = savedInstanceState
+        locationPermissionCheckAndStart()
+    }
+
+    override fun onMapReady(mapboxMap: MapboxMap) {
+        this.mapboxMap = mapboxMap
+        mapboxMap.setStyle(Style.Builder().fromUri(
+
+                // TODO: Because of privacy reasons, this file isn't actually included
+                //  in the app. Add the file to an assets folder.
+                //  Please email Mapbox at apac-bd@mapbox.com if you're
+                //  interested in this file and/or have questions about
+                //  this general functionality.
+                if (deviceInChina!!) chinaStyleToUse else
+                    "asset://cn_style_with_english_labels.json")) {
+
+            Toast.makeText(this@ChinaBoundsCheckerActivity,
+                    String.format(getString(R.string.device_location),
+                            if (deviceInChina!!) "is" else "isn't"), Toast.LENGTH_SHORT).show()
+
+            initLocationComponent(it)
+        }
+    }
+
+    override fun onSuccess(result: LocationEngineResult?) {
+        val lastLocation = result?.lastLocation
+        if (deviceInChina == null) {
+            deviceInChina = ChinaBoundsChecker.locationIsInChina(
+                    this@ChinaBoundsCheckerActivity, result?.lastLocation)
+            initMap(
+                    MapboxMapOptions.createFromAttributes(this, null)
+                            .camera(
+                                    CameraPosition.Builder()
+                                            .target(LatLng(lastLocation?.latitude!!,
+                                                    lastLocation.longitude))
+                                            .zoom(10.0)
+                                            .build()),
+                    savedInstanceState)
+        }
+        locationComponent?.forceLocationUpdate(lastLocation)
+    }
+
+    override fun onFailure(exception: Exception) {
+        Toast.makeText(this, String.format("get location failed: %s",
+                exception.localizedMessage), Toast.LENGTH_SHORT).show()
+    }
+
+    private fun locationPermissionCheckAndStart() {
+        // Check if permissions are enabled and if not request
+        if (PermissionsManager.areLocationPermissionsGranted(this)) {
+            initLocationEngine()
+        } else {
+            permissionsManager = PermissionsManager(this).apply {
+            requestLocationPermissions(this@ChinaBoundsCheckerActivity)
+            }
+        }
+    }
+
+    private fun initMap(
+      mapboxMapOptions: MapboxMapOptions,
+      savedInstanceState: Bundle?
+    ) {
+        chinaMapView = ChinaMapView(this, mapboxMapOptions).apply {
+            onCreate(savedInstanceState)
+            getMapAsync(this@ChinaBoundsCheckerActivity)
+            setContentView(this)
+        }
+    }
+
+    @SuppressWarnings("MissingPermission")
+    fun initLocationComponent(@NonNull fullyLoadedStyle: Style) {
+        locationComponent = mapboxMap.locationComponent
+        locationComponent?.apply {
+            // Activate the LocationComponent with LocationComponentActivationOptions
+            activateLocationComponent(LocationComponentActivationOptions.builder(
+                    this@ChinaBoundsCheckerActivity,
+                    fullyLoadedStyle).build())
+
+            // Enable to make the LocationComponent visible
+            isLocationComponentEnabled = true
+
+            // Set the LocationComponent's camera mode
+            cameraMode = CameraMode.NONE
+
+            // Set the LocationComponent's render mode
+            renderMode = RenderMode.NORMAL
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun initLocationEngine() {
+        locationEngine = LocationEngineProvider.getBestLocationEngine(this).apply {
+            requestLocationUpdates(LocationEngineRequest.Builder(defaultIntervalInMilliseconds)
+                    .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+                    .setMaxWaitTime(defaultMaxWaitTime).build(),
+                    this@ChinaBoundsCheckerActivity, mainLooper)
+            getLastLocation(this@ChinaBoundsCheckerActivity)
+        }
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        permissionsManager?.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    }
+
+    override fun onExplanationNeeded(permissionsToExplain: List<String>) {
+        Toast.makeText(this, R.string.user_location_permission_explanation, Toast.LENGTH_LONG).show()
+    }
+
+    override fun onPermissionResult(granted: Boolean) {
+        if (granted) {
+            locationPermissionCheckAndStart()
+        } else {
+            Toast.makeText(this, R.string.user_location_permission_not_granted, Toast.LENGTH_LONG).show()
+            finish()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        chinaMapView?.onResume()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        chinaMapView?.onStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        chinaMapView?.onStop()
+    }
+
+    public override fun onPause() {
+        super.onPause()
+        chinaMapView?.onPause()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        chinaMapView?.onLowMemory()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        chinaMapView?.onDestroy()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        chinaMapView?.onSaveInstanceState(outState)
+    }
+}

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -996,6 +996,14 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
+        <activity
+            android:name=".examples.ChinaBoundsCheckerActivity"
+            android:label="@string/activity_china_simple_china_bounds_checker_title"
+            android:screenOrientation="portrait">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
 
         <service android:name=".account.AccountRetrievalService" />
     <receiver android:name=".utils.DemoAppHomeScreenAddressWidget">

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -424,4 +424,7 @@
     <!-- Variable label placement-->
     <string name="zoom_map_in_and_out_circle_to_icon_transition">Zoom in and out to see the circles transition to icons</string>
 
+    <!-- China bounds checker-->
+    <string name="device_location">Device %1$s in China</string>
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -136,5 +136,6 @@
     <string name="activity_lab_change_attribution_color_description">Adjust the attribution "i" to match a map style, app UI, or color motif.</string>
     <string name="activity_lab_shared_preferences_description">Use the Android system\'s Shared Preferences to save and retrieve coordinates.</string>
     <string name="activity_china_simple_china_mapview_description">Show an accurate and government-approved China map in your app using the Mapbox Maps SDK.</string>
+    <string name="activity_china_simple_china_bounds_checker_description">Use the China plugin to determine whether or not the device is inside of China.</string>
 
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -131,6 +131,7 @@
     <string name="activity_dds_polygon_select_toggle_title">Polygon toggle</string>
     <string name="activity_lab_drag_draw_title">Drawing search area</string>
     <string name="activity_china_simple_china_mapview_title">China map view</string>
+    <string name="activity_china_simple_china_bounds_checker_title">Device in China</string>
     <string name="activity_lab_home_screen_widget_title">Homescreen geocoding widget</string>
     <string name="activity_lab_rv_directions_title">RecyclerView Directions</string>
     <string name="activity_lab_spinning_icon_title">Spinning icon</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -134,4 +134,5 @@
     <string name="activity_lab_change_attribution_color_url" translatable="false">https://i.imgur.com/cGv98jb.png</string>
     <string name="activity_lab_shared_preferences_url" translatable="false">https://i.imgur.com/znxAhDG.png</string>
     <string name="activity_china_simple_china_mapview_url" translatable="false">https://i.imgur.com/KwoEynZ.png</string>
+    <string name="activity_china_simple_china_bounds_checker_url" translatable="false">https://i.imgur.com/fIFWqJu.png</string>
 </resources>


### PR DESCRIPTION
Mirror of mapbox mapbox-android-demo#1252
Resolves #1251 by adding an example to the China flavor to show how to use the `ChinaBoundsChecker` class. 

Related `/android-docs` pr is at https://github.com/mapbox/android-docs/pull/1125

cc <at>julieemunro <at>chriswu42 

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/67127778-d7490080-f1ae-11e9-85f2-2378417606da.gif)

