### PR TITLE
Mirror of mapbox mapbox-android-demo#1266

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ ext {
             mapboxPluginPlaces       : '0.9.0',
             mapboxPluginLocalization : '0.11.0',
             mapboxPluginTraffic      : '0.9.0',
-            mapboxChinaPlugin        : '2.3.0',
+            mapboxChinaPlugin        : '2.4.0',
             mapboxPluginMarkerView   : '0.3.0',
             mapboxPluginAnnotation   : '0.7.0',
             mapboxPluginScalebar     : '0.3.0',


### PR DESCRIPTION
Mirror of mapbox mapbox-android-demo#1266
Part of the 2.4.0 release of the Mapbox China Plugin for Android, which is part of the 8.5.0 release of the Mapbox Maps SDK for Android.
