### PR TITLE
Mirror of mapbox mapbox-android-demo#1326

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+## 9.1.0 - April 8, 2020
+
+- Bumped Maps SDK to 9.1.0 #[1324](https://github.com/mapbox/mapbox-android-demo/pull/1324)
+- Fixed tools:context in activity_basic_simple_kotlin.xml #[1320](https://github.com/mapbox/mapbox-android-demo/pull/1320)
+- Bumped scalebar plugin to 0.5.0 #[1323](https://github.com/mapbox/mapbox-android-demo/pull/1323)
+- Places plugin 0.11.0 bump #[1322](https://github.com/mapbox/mapbox-android-demo/pull/1322)
+- Bumped Java SDK to 5.1.0 #[1319](https://github.com/mapbox/mapbox-android-demo/pull/1319)
+- Bumped plugin dependencies and prefix for v9 plugin release #[1309](https://github.com/mapbox/mapbox-android-demo/pull/1309)
+
 ## 9.0.0 - March 2nd, 2020
 
 - Bumped the Maps SDK to 9.0.0 #[1305](https://github.com/mapbox/mapbox-android-demo/pull/1305)

--- a/MapboxAndroidDemo/src/global/play/release-notes/en-US/default.txt
+++ b/MapboxAndroidDemo/src/global/play/release-notes/en-US/default.txt
@@ -1,9 +1,1 @@
-This update is part of the 9.0.0 release of the Mapbox Maps SDK for Android.  New examples include:
-
-• Circle icon toggling onClick
-• Baseball spray chart
-• Directions profile toggle
-• Zooming to cluster leaves
-• Tilequery API + Static Images API notification
-• Straight line Turf distance measurement ("as the crow flies")
-• SymbolLayer icon dependent on a Feature property
+This update is part of the 9.1.0 release of the Mapbox Maps SDK for Android.


### PR DESCRIPTION
Mirror of mapbox mapbox-android-demo#1326
References #1325 as part of the 9.1.0 release of this app, which is part of the 9.1.0 release of the Maps SDK for Android.


